### PR TITLE
Immutable DateTime.

### DIFF
--- a/features/Context/AbstractBaseContext.php
+++ b/features/Context/AbstractBaseContext.php
@@ -238,7 +238,7 @@ abstract class AbstractBaseContext implements SnippetAcceptingContext
      */
     public function theTimeIs($arg1, $arg2)
     {
-        $this->clock->getTime()->willReturn(new \DateTime('@' . mktime($arg1, $arg2)));
+        $this->clock->getTime()->willReturn(new \DateTimeImmutable('@' . mktime($arg1, $arg2)));
     }
 
     /**

--- a/src/ClockInterface.php
+++ b/src/ClockInterface.php
@@ -5,5 +5,5 @@ namespace MGDigital\BusQue;
 interface ClockInterface
 {
 
-    public function getTime(): \DateTime;
+    public function getTime(): \DateTimeImmutable;
 }

--- a/src/Redis/RedisDriver.php
+++ b/src/Redis/RedisDriver.php
@@ -151,9 +151,9 @@ final class RedisDriver implements QueueDriverInterface, SchedulerDriverInterfac
     }
 
     public function receiveDueCommands(
-        \DateTime $now,
+        \DateTimeInterface $now,
         int $limit = SchedulerWorker::DEFAULT_THROTTLE,
-        \DateTime $startTime = null
+        \DateTimeInterface $startTime = null
     ): array {
         if ($startTime === null) {
             $start = 0;

--- a/src/SchedulerDriverInterface.php
+++ b/src/SchedulerDriverInterface.php
@@ -19,14 +19,14 @@ interface SchedulerDriverInterface
     public function getScheduledTime(string $queueName, string $id);
 
     /**
-     * @param \DateTime $now
+     * @param \DateTimeInterface $now
      * @param int $limit The maximum number of scheduled commands to return.
-     * @param \DateTime|null $startTime Return due commands since $startTime or the beginning of time.
+     * @param \DateTimeInterface|null $startTime Return due commands since $startTime or the beginning of time.
      * @return ReceivedScheduledCommand[]
      */
     public function receiveDueCommands(
-        \DateTime $now,
+        \DateTimeInterface $now,
         int $limit = SchedulerWorker::DEFAULT_THROTTLE,
-        \DateTime $startTime = null
+        \DateTimeInterface $startTime = null
     ): array;
 }

--- a/src/SchedulerWorker.php
+++ b/src/SchedulerWorker.php
@@ -51,8 +51,7 @@ class SchedulerWorker
         if ($expiry === null) {
             $start = null;
         } else {
-            $start = clone $now;
-            $start = $start->sub($expiry);
+            $start = $now->sub($expiry);
         }
         $receivedCommands = $this->implementation->getSchedulerDriver()
             ->receiveDueCommands($now, $throttle, $start);

--- a/src/SystemClock.php
+++ b/src/SystemClock.php
@@ -5,8 +5,8 @@ namespace MGDigital\BusQue;
 class SystemClock implements ClockInterface
 {
 
-    public function getTime(): \DateTime
+    public function getTime(): \DateTimeImmutable
     {
-        return new \DateTime();
+        return new \DateTimeImmutable();
     }
 }


### PR DESCRIPTION
Stops the need to clone variables, also makes sure that the instances from the clock interface are immutable.
